### PR TITLE
Bump Caddy from 2.8.4 to 2.10.2 and pin builder image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker buildx create --name "caddy-cloudflare" --use
       - run: docker buildx build --platform linux/amd64,linux/arm64/v8 --push --pull --force-rm --tag "ghcr.io/${{ github.repository }}:latest" --file Dockerfile .
       # - run: docker push --all-tags "ghcr.io/${{ github.repository }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:builder AS builder
+FROM caddy:2.10.2-builder AS builder
 
 RUN xcaddy build \
       --with github.com/caddy-dns/cloudflare \
@@ -6,7 +6,7 @@ RUN xcaddy build \
 
 ################################################################################
 
-FROM caddy:2.8.4
+FROM caddy:2.10.2
 
 LABEL "org.opencontainers.image.source"="https://github.com/andrius/caddy-cloudflare"
 LABEL "org.opencontainers.image.description"="Caddy with cloudflare DNS module"


### PR DESCRIPTION
- Update runtime image from caddy:2.8.4 to caddy:2.10.2 (latest stable)
- Pin builder image to caddy:2.10.2-builder for reproducible builds
- Bump actions/checkout from v3 to v4 in CI workflow

https://claude.ai/code/session_01LfENoHVpf3ZN21avSKvvex